### PR TITLE
fix dashboard layout for responsive

### DIFF
--- a/app/(dashboard)/dashboard/page.js
+++ b/app/(dashboard)/dashboard/page.js
@@ -1,42 +1,40 @@
 "use client";
 import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage,
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbList,
+    BreadcrumbPage,
 } from "@/components/ui/breadcrumb";
-import { Separator } from "@/components/ui/separator";
+import {Separator} from "@/components/ui/separator";
 import {
-  SidebarInset,
-  SidebarTrigger,
+    SidebarInset,
+    SidebarTrigger,
 } from "@/components/ui/sidebar";
 
 import DressShowcase from "@/components/dashboard/Product/ProductShowcase";
 
 export default function Page() {
-  return (
-      <SidebarInset>
-        <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
-            <SidebarTrigger className="-ml-1" />
-          <Separator orientation="vertical" className="mr-2 h-4" />
-          <Breadcrumb>
-            <BreadcrumbList>
-              <BreadcrumbItem className="hidden md:block">
-                <BreadcrumbPage>Dashboard</BreadcrumbPage>
-              </BreadcrumbItem>
-            </BreadcrumbList>
-          </Breadcrumb>
-          <Separator orientation="vertical" className="mr-2 h-4" />
-        </header>
-        <div className="flex flex-1 flex-col gap-4 p-4">
-          <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-            <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min" />
-            <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min" />
-            <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min" />
-          </div>
-          <div className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min" />
-          <DressShowcase/>
-        </div>
-      </SidebarInset>
-  );
+    return (
+        <SidebarInset>
+            <header
+                className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+                <SidebarTrigger className="-ml-1"/>
+                <Separator orientation="vertical" className="mr-2 h-4"/>
+                <Breadcrumb>
+                    <BreadcrumbList>
+                        <BreadcrumbItem className="md:block">
+                            <BreadcrumbPage>Dashboard</BreadcrumbPage>
+                        </BreadcrumbItem>
+                    </BreadcrumbList>
+                </Breadcrumb>
+                <Separator orientation="vertical" className="mr-2 h-4"/>
+            </header>
+            <div className="flex flex-1 flex-col gap-4 p-4">
+                <div className="grid auto-rows-min gap-4 md:grid-cols-3">
+                </div>
+                <div className="flex-1 rounded-xl bg-muted/50 md:min-h-min"/>
+                <DressShowcase/>
+            </div>
+        </SidebarInset>
+    );
 }

--- a/app/(dashboard)/dashboard/product/add/page.js
+++ b/app/(dashboard)/dashboard/product/add/page.js
@@ -27,14 +27,16 @@ export default function Page() {
                 <Separator orientation="vertical" className="mr-2 h-4"/>
                 <Breadcrumb>
                     <BreadcrumbList>
-                        <BreadcrumbItem className="hidden md:block">
-                            <BreadcrumbLink href="/dashboard">Dashboard</BreadcrumbLink>
+                        <BreadcrumbItem className="md:block">
+                            <BreadcrumbLink
+                                href="/dashboard">Dashboard</BreadcrumbLink>
                         </BreadcrumbItem>
-                        <BreadcrumbSeparator className="hidden md:block"/>
+                        <BreadcrumbSeparator className="md:block"/>
                         <BreadcrumbItem>
-                            <BreadcrumbLink href="/dashboard/product">Product</BreadcrumbLink>
+                            <BreadcrumbLink
+                                href="/dashboard/product">Product</BreadcrumbLink>
                         </BreadcrumbItem>
-                        <BreadcrumbSeparator className="hidden md:block"/>
+                        <BreadcrumbSeparator className="md:block"/>
                         <BreadcrumbItem>
                             <BreadcrumbPage>Add Product</BreadcrumbPage>
                         </BreadcrumbItem>
@@ -47,7 +49,7 @@ export default function Page() {
                 </div>
                 <AddProduct/>
                 <div
-                    className="min-h-[100vh] flex-1 rounded-xl bg-muted/50 md:min-h-min"/>
+                    className="flex-1 rounded-xl bg-muted/50 md:min-h-min"/>
             </div>
         </SidebarInset>
     );

--- a/app/(dashboard)/dashboard/product/list/page.js
+++ b/app/(dashboard)/dashboard/product/list/page.js
@@ -23,15 +23,15 @@ export default function Page() {
                 <Separator orientation="vertical" className="mr-2 h-4"/>
                 <Breadcrumb>
                     <BreadcrumbList>
-                        <BreadcrumbItem className="hidden md:block">
+                        <BreadcrumbItem className="md:block">
                             <BreadcrumbLink
                                 href="/dashboard">Dashboard</BreadcrumbLink>
                         </BreadcrumbItem>
-                        <BreadcrumbSeparator className="hidden md:block"/>
+                        <BreadcrumbSeparator className="md:block"/>
                         <BreadcrumbItem>
                             <BreadcrumbLink href="/dashboard/product">Product</BreadcrumbLink>
                         </BreadcrumbItem>
-                        <BreadcrumbSeparator className="hidden md:block"/>
+                        <BreadcrumbSeparator className="md:block"/>
                         <BreadcrumbItem>
                             <BreadcrumbPage>Product List</BreadcrumbPage>
                         </BreadcrumbItem>

--- a/app/(dashboard)/dashboard/product/page.js
+++ b/app/(dashboard)/dashboard/product/page.js
@@ -24,15 +24,15 @@ export default function Page() {
                 <Separator orientation="vertical" className="mr-2 h-4"/>
                 <Breadcrumb>
                     <BreadcrumbList>
-                        <BreadcrumbItem className="hidden md:block">
+                        <BreadcrumbItem className="md:block">
                             <BreadcrumbLink
                                 href="/dashboard">Dashboard</BreadcrumbLink>
                         </BreadcrumbItem>
-                        <BreadcrumbSeparator className="hidden md:block"/>
+                        <BreadcrumbSeparator className="md:block"/>
                         <BreadcrumbItem>
                             <BreadcrumbPage>Product</BreadcrumbPage>
                         </BreadcrumbItem>
-                        <BreadcrumbSeparator className="hidden md:block"/>
+                        <BreadcrumbSeparator className="md:block"/>
                         <BreadcrumbItem>
                             <BreadcrumbLink
                                 href="/dashboard/product/add">Add Product</BreadcrumbLink>

--- a/components/dashboard/Product/ProductShowcase.jsx
+++ b/components/dashboard/Product/ProductShowcase.jsx
@@ -182,7 +182,7 @@ export default function DressShowcase() {
           </motion.h1>
           <FilterPanel onFilterChange={handleFilterChange} />
         </div>
-        <div id="product-section" className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 mt-6">
+        <div id="product-section" className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6 mt-6">
           {loading
             ? Array.from({ length: dresses.length || ITEMS_PER_PAGE }).map((_, index) => <ProductSkeleton key={index} />)
             : currentDresses.map((dress) => (


### PR DESCRIPTION
This pull request includes several changes to improve the layout and consistency of the dashboard pages and the product showcase component. The most important changes are related to the visibility of breadcrumb items and the grid layout for the product showcase.

Improvements to breadcrumb visibility:

* [`app/(dashboard)/dashboard/page.js`](diffhunk://#diff-2e5e727d4637d4bd855011364e29d1270be60041dc4a0d09499cf8f0f5cd1f94L19-R25): Modified `BreadcrumbItem` and `BreadcrumbSeparator` components to always be visible by removing the `hidden` class and ensuring they are displayed in `md` screens. [[1]](diffhunk://#diff-2e5e727d4637d4bd855011364e29d1270be60041dc4a0d09499cf8f0f5cd1f94L19-R25) [[2]](diffhunk://#diff-2e5e727d4637d4bd855011364e29d1270be60041dc4a0d09499cf8f0f5cd1f94L33-R35)
* [`app/(dashboard)/dashboard/product/add/page.js`](diffhunk://#diff-ae45b8dcc521cc2fa3df47ca038f547f496881a03cd9eab547dc65b82077d26dL30-R39): Updated breadcrumb items and separators to be visible on medium screens and above. [[1]](diffhunk://#diff-ae45b8dcc521cc2fa3df47ca038f547f496881a03cd9eab547dc65b82077d26dL30-R39) [[2]](diffhunk://#diff-ae45b8dcc521cc2fa3df47ca038f547f496881a03cd9eab547dc65b82077d26dL50-R52)
* [`app/(dashboard)/dashboard/product/list/page.js`](diffhunk://#diff-323e5e818fda77792a1c92180a0a912497c2c39fb77644916830d6eb66c68e30L26-R34): Ensured breadcrumb items and separators are visible on medium screens and above.
* [`app/(dashboard)/dashboard/product/page.js`](diffhunk://#diff-4ef88845d3f34b3d69aeefc399559b277e4afcab3b4ea828e4c3413dc62077a9L27-R35): Made breadcrumb items and separators visible on medium screens and above.

Enhancements to product showcase layout:

* [`components/dashboard/Product/ProductShowcase.jsx`](diffhunk://#diff-ccd88d7f1e45c8aeee75cfad77ff3330d4cbde628a2268ab26eacf3d73ffdf9eL185-R185): Adjusted the grid layout of the product showcase to display two columns on small screens and up to four columns on large screens.